### PR TITLE
Cython Setup Fixes for stabilizing installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "Cython>=0.29.1"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,20 @@
 #!/usr/bin/env python3
 
 from setuptools import setup
-from Cython.Build import cythonize
 from distutils.extension import Extension
-from Cython.Distutils import build_ext
+
+try:
+    from Cython.Build import cythonize
+    from Cython.Distutils import build_ext
+except ImportError:
+    def cythonize(*args, **kwargs):
+        from Cython.Build import cythonize
+        return cythonize(*args, **kwargs)
+
+    def build_ext(*args, **kwargs):
+        from Cython.Distutils import build_ext
+        return build_ext(*args, **kwargs)
+
 # import os
 # os.environ['CFLAGS'] = '-O0'
 try:

--- a/setup.py
+++ b/setup.py
@@ -3,27 +3,13 @@
 from setuptools import setup
 from distutils.extension import Extension
 
-ext_modules = [
-    Extension(
-        'util',
-        sources=["lib/cyac/util.pyx"],
-    ),
-    Extension(
-        'utf8',
-        sources=["lib/cyac/utf8.pyx"],
-    ),
-    Extension(
-        'xstring',
-        sources=["lib/cyac/xstring.pyx"],
-    ),
-    Extension(
-        'trie',
-        sources=["lib/cyac/trie.pyx"],
-    ),
-    Extension(
-        'ac',
-        sources=["lib/cyac/ac.pyx"],
-    ),]
+# Delayed import; https://stackoverflow.com/questions/37471313/setup-requires-with-cython
+try:
+    from Cython.Build import cythonize
+except ImportError:
+     def cythonize(*args, **kwargs):
+         from Cython.Build import cythonize
+         return cythonize(*args, **kwargs)
 
 # import os
 # os.environ['CFLAGS'] = '-O0'
@@ -45,9 +31,14 @@ setup(
     include_package_data=True,
     long_description_content_type="text/markdown",
     long_description=long_description,
-    install_requires=["cython"],
+    install_requires=['cython>=0.29.0', 'Cython>=0.29.0'],
     setup_requires=['Cython'],
-    ext_modules = ext_modules,
+    ext_modules = cythonize([
+        "lib/cyac/util.pyx",
+        "lib/cyac/utf8.pyx",
+        "lib/cyac/xstring.pyx",
+        "lib/cyac/trie.pyx", 
+        "lib/cyac/ac.pyx"]),
     classifiers=[
         'Operating System :: POSIX :: Linux',
         'Operating System :: MacOS :: MacOS X',

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     long_description_content_type="text/markdown",
     long_description=long_description,
     install_requires=["cython"],
+    setup_requires=['Cython'],
     ext_modules = cythonize([
         "lib/cyac/util.pyx",
         "lib/cyac/utf8.pyx",

--- a/setup.py
+++ b/setup.py
@@ -3,17 +3,27 @@
 from setuptools import setup
 from distutils.extension import Extension
 
-try:
-    from Cython.Build import cythonize
-    from Cython.Distutils import build_ext
-except ImportError:
-    def cythonize(*args, **kwargs):
-        from Cython.Build import cythonize
-        return cythonize(*args, **kwargs)
-
-    def build_ext(*args, **kwargs):
-        from Cython.Distutils import build_ext
-        return build_ext(*args, **kwargs)
+ext_modules = [
+    Extension(
+        'util',
+        sources=["lib/cyac/util.pyx"],
+    ),
+    Extension(
+        'utf8',
+        sources=["lib/cyac/utf8.pyx"],
+    ),
+    Extension(
+        'xstring',
+        sources=["lib/cyac/xstring.pyx"],
+    ),
+    Extension(
+        'trie',
+        sources=["lib/cyac/trie.pyx"],
+    ),
+    Extension(
+        'ac',
+        sources=["lib/cyac/ac.pyx"],
+    ),]
 
 # import os
 # os.environ['CFLAGS'] = '-O0'
@@ -37,12 +47,7 @@ setup(
     long_description=long_description,
     install_requires=["cython"],
     setup_requires=['Cython'],
-    ext_modules = cythonize([
-        "lib/cyac/util.pyx",
-        "lib/cyac/utf8.pyx",
-        "lib/cyac/xstring.pyx",
-        "lib/cyac/trie.pyx", 
-        "lib/cyac/ac.pyx"]),
+    ext_modules = ext_modules,
     classifiers=[
         'Operating System :: POSIX :: Linux',
         'Operating System :: MacOS :: MacOS X',


### PR DESCRIPTION
Great library!

I was trying to install cyac using pants (https://github.com/pantsbuild/pants) but ran into issues because you need to have Cython involved ahead of time in the desired venv.

Other Cython libraries I have worked with don't follow this approach, but instead leverage the Python setup.py/distutils to specify the Cython dependency.

The library "lark_cython" handles this with this code changes in this PR.

You can see that project here:
https://github.com/lark-parser/lark_cython

Hope this is helpful and can make it into future builds. Until such time, I am using the following requirement to install via Pants:

git+https://github.com/imaurer/cyac.git@master#egg=cyac
